### PR TITLE
Add CUDA 10.0 build

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -13,7 +13,7 @@ jobs:
       linux_target_platformlinux-64:
         CONFIG: linux_target_platformlinux-64
         UPLOAD_PACKAGES: True
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.0
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/.ci_support/linux_target_platformlinux-64.yaml
+++ b/.ci_support/linux_target_platformlinux-64.yaml
@@ -11,6 +11,6 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-cuda:10.0
 target_platform:
 - linux-64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,1 +1,9 @@
-docker_image: condaforge/linux-anvil-cuda:10.0
+docker_image:
+  - condaforge/linux-anvil-cuda:10.0
+  - condaforge/linux-anvil-cuda:9.2
+CUDA_VER:
+  - 10.0
+  - 9.2
+zip_keys:
+  - - CUDA_VER
+    - docker_image

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,1 @@
+docker_image: condaforge/linux-anvil-cuda:10.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set name = "nvcc" %}
-{% set version = environ.get("CUDA_VER", "10.0") %}
 
 package:
   name: "{{ name }}"
@@ -10,7 +9,7 @@ build:
 
 outputs:
   - name: "{{ name }}_{{ target_platform }}"
-    version: "{{ version }}"
+    version: "{{ CUDA_VER }}"
     script: install_nvcc.sh
     build:
       script_env:
@@ -19,7 +18,7 @@ outputs:
         - libgcc-ng
       run_exports:
         strong:
-          - cudatoolkit {{ version }}|{{ version }}.*
+          - cudatoolkit {{ CUDA_VER }}|{{ CUDA_VER }}.*
     requirements:
       host:
         # Needed to symlink libcuda into sysroot libs.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set version = environ.get("CUDA_VER", "9.2") %}
+{% set version = environ.get("CUDA_VER", "10.0") %}
 
 package:
   name: "{{ name }}"


### PR DESCRIPTION
Builds the `nvcc` (shim compiler) package for CUDA 10.0.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
