### PR TITLE
Build and deploy nvcc versions

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -13,7 +13,7 @@ jobs:
       linux_target_platformlinux-64:
         CONFIG: linux_target_platformlinux-64
         UPLOAD_PACKAGES: True
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.0
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,10 +10,18 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_target_platformlinux-64:
-        CONFIG: linux_target_platformlinux-64
+      linux_CUDA_VER10.0target_platformlinux-64:
+        CONFIG: linux_CUDA_VER10.0target_platformlinux-64
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.0
+      linux_CUDA_VER10.1target_platformlinux-64:
+        CONFIG: linux_CUDA_VER10.1target_platformlinux-64
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
+      linux_CUDA_VER9.2target_platformlinux-64:
+        CONFIG: linux_CUDA_VER9.2target_platformlinux-64
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:9.2
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/.ci_support/linux_CUDA_VER10.0target_platformlinux-64.yaml
+++ b/.ci_support/linux_CUDA_VER10.0target_platformlinux-64.yaml
@@ -1,0 +1,21 @@
+CUDA_VER:
+- '10.0'
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-cuda:10.0
+target_platform:
+- linux-64
+zip_keys:
+- - CUDA_VER
+  - docker_image

--- a/.ci_support/linux_CUDA_VER10.1target_platformlinux-64.yaml
+++ b/.ci_support/linux_CUDA_VER10.1target_platformlinux-64.yaml
@@ -1,3 +1,5 @@
+CUDA_VER:
+- '10.1'
 c_compiler:
 - gcc
 c_compiler_version:
@@ -11,6 +13,9 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.0
+- condaforge/linux-anvil-cuda:10.1
 target_platform:
 - linux-64
+zip_keys:
+- - CUDA_VER
+  - docker_image

--- a/.ci_support/linux_CUDA_VER9.2target_platformlinux-64.yaml
+++ b/.ci_support/linux_CUDA_VER9.2target_platformlinux-64.yaml
@@ -1,0 +1,21 @@
+CUDA_VER:
+- '9.2'
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-cuda:9.2
+target_platform:
+- linux-64
+zip_keys:
+- - CUDA_VER
+  - docker_image

--- a/.ci_support/linux_target_platformlinux-64.yaml
+++ b/.ci_support/linux_target_platformlinux-64.yaml
@@ -11,6 +11,6 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-cuda:10.0
 target_platform:
 - linux-64

--- a/README.md
+++ b/README.md
@@ -29,10 +29,24 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_target_platformlinux-64</td>
+              <td>linux_CUDA_VER10.0target_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7480&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcc-feedstock?branchName=master&jobName=linux&configuration=linux_target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcc-feedstock?branchName=master&jobName=linux&configuration=linux_CUDA_VER10.0target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_CUDA_VER10.1target_platformlinux-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7480&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcc-feedstock?branchName=master&jobName=linux&configuration=linux_CUDA_VER10.1target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_CUDA_VER9.2target_platformlinux-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7480&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcc-feedstock?branchName=master&jobName=linux&configuration=linux_CUDA_VER9.2target_platformlinux-64" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,1 +1,9 @@
-docker_image: condaforge/linux-anvil-cuda:10.0
+docker_image:
+  - condaforge/linux-anvil-cuda:10.0
+  - condaforge/linux-anvil-cuda:9.2
+CUDA_VER:
+  - 10.0
+  - 9.2
+zip_keys:
+  - - CUDA_VER
+    - docker_image

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,1 @@
+docker_image: condaforge/linux-anvil-cuda:10.0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,9 @@
 docker_image:
+  - condaforge/linux-anvil-cuda:10.1
   - condaforge/linux-anvil-cuda:10.0
   - condaforge/linux-anvil-cuda:9.2
 CUDA_VER:
+  - 10.1
   - 10.0
   - 9.2
 zip_keys:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set name = "nvcc" %}
-{% set version = environ.get("CUDA_VER", "10.0") %}
 
 package:
   name: "{{ name }}"
@@ -10,7 +9,7 @@ build:
 
 outputs:
   - name: "{{ name }}_{{ target_platform }}"
-    version: "{{ version }}"
+    version: "{{ CUDA_VER }}"
     script: install_nvcc.sh
     build:
       script_env:
@@ -19,7 +18,7 @@ outputs:
         - libgcc-ng
       run_exports:
         strong:
-          - cudatoolkit {{ version }}|{{ version }}.*
+          - cudatoolkit {{ CUDA_VER }}|{{ CUDA_VER }}.*
     requirements:
       host:
         # Needed to symlink libcuda into sysroot libs.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set version = environ.get("CUDA_VER", "9.2") %}
+{% set version = environ.get("CUDA_VER", "10.0") %}
 
 package:
   name: "{{ name }}"


### PR DESCRIPTION
Builds out all of the version of the `nvcc` compiler package. Supersedes previous attempts by building all CUDA versions in one branch.

Edit: FYI build number does not need to change as this has yet to be published.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes https://github.com/conda-forge/nvcc-feedstock/pull/5
Closes https://github.com/conda-forge/nvcc-feedstock/pull/4

<!--
Please add any other relevant info below:
-->
