### PR TITLE
Overwrite the `libcuda.so` symlink if present

### DIFF
--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -52,7 +52,7 @@ export CXXFLAGS="\${CXXFLAGS} -I\${CUDA_HOME}/include"
 
 CONDA_ENV_SYSROOT="\$(\${CC} --print-sysroot)"
 mkdir -p "\${CONDA_ENV_SYSROOT}/lib"
-ln -s "\${CUDA_HOME}/lib64/stubs/libcuda.so" "\${CONDA_ENV_SYSROOT}/lib/libcuda.so"
+ln -sf "\${CUDA_HOME}/lib64/stubs/libcuda.so" "\${CONDA_ENV_SYSROOT}/lib/libcuda.so"
 EOF
 
 # Unset `CUDA_HOME` in a deactivation script.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set number = 1 %}
+{% set number = 2 %}
 
 package:
   name: "{{ name }}"


### PR DESCRIPTION
As the `libcuda.so` symlink could have been added during a previous activation (and deactivation may not have occurred yet, like logging out), the symlink may already be there when we try to create it. In this case, just go ahead and forcibly overwrite the symlink with a new one.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Note: Re-rendering is currently broken for this feedstock. ( https://github.com/conda-forge/nvcc-feedstock/issues/18 ) So not handling that in this PR.