### PR TITLE
Use `return` in activate/deactivate scripts

### DIFF
--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -20,25 +20,25 @@ then
         CUDA_HOME=\$(dirname \$(dirname \$CUDA_GDB_EXECUTABLE))
     else
         echo "Cannot determine CUDA_HOME: cuda-gdb not in PATH"
-        exit 1
+        return 1
     fi
 fi
 
 if [[ ! -d "\${CUDA_HOME}" ]]
 then
     echo "Directory \${CUDA_HOME} doesn't exist"
-    exit 1
+    return 1
 fi
 
 if [[ ! -f "\${CUDA_HOME}/lib64/stubs/libcuda.so" ]]
 then
     echo "File \${CUDA_HOME}/lib64/stubs/libcuda.so doesn't exist"
-    exit 1
+    return 1
 fi
 
 if [[ \$(grep -q "CUDA Version ${PKG_VERSION}" \${CUDA_HOME}/version.txt) -ne 0 ]]; then
     echo "Version of installed CUDA didn't match package"
-    exit 1
+    return 1
 fi
 
 export CUDA_HOME="\${CUDA_HOME}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set number = 3 %}
+{% set number = 4 %}
 
 package:
   name: "{{ name }}"


### PR DESCRIPTION
Partially addresses https://github.com/conda-forge/nvcc-feedstock/issues/22

With scripts that are being sourced, it is recommended to use `return` instead of `exit`. This ensure the sourced script errors out without accidently exiting from a user session as well.

cc @pearu

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
