### PR TITLE
Improve handling of environment variables CUDA_HOME, CFLAGS, CXXFLAGS, CPPFLAGS

### DIFF
--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -29,10 +29,11 @@ then
 fi
 
 # Default to using \$(cuda-gdb) to specify \$(CUDA_HOME).
-if [ -z "\${CUDA_HOME+x}" ]
+if [[ -z "\${CUDA_HOME+x}" ]]
 then
     CUDA_GDB_EXECUTABLE=\$(which cuda-gdb)
-    if [ -n "\$CUDA_GDB_EXECUTABLE" ]; then
+    if [[ -n "\$CUDA_GDB_EXECUTABLE" ]]
+    then
         CUDA_HOME=\$(dirname \$(dirname \$CUDA_GDB_EXECUTABLE))
     else
         echo "Cannot determine CUDA_HOME: cuda-gdb not in PATH"
@@ -52,7 +53,8 @@ then
     return 1
 fi
 
-if [[ \$(grep -q "CUDA Version ${PKG_VERSION}" \${CUDA_HOME}/version.txt) -ne 0 ]]; then
+if [[ \$(grep -q "CUDA Version ${PKG_VERSION}" \${CUDA_HOME}/version.txt) -ne 0 ]]
+then
     echo "Version of installed CUDA didn't match package"
     return 1
 fi
@@ -98,10 +100,13 @@ then
 fi
 
 if [[ ! -z "\${CPPFLAGS_CONDA_NVCC_BACKUP+x}" ]]
+then
   export CPPFLAGS="\${CPPFLAGS_CONDA_NVCC_BACKUP}"
   unset CPPFLAGS_CONDA_NVCC_BACKUP
 fi
+
 if [[ ! -z "\${CXXFLAGS_CONDA_NVCC_BACKUP+x}" ]]
+then
   export CXXFLAGS="\${CXXFLAGS_CONDA_NVCC_BACKUP}"
   unset CXXFLAGS_CONDA_NVCC_BACKUP
 fi

--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -23,7 +23,7 @@ then
   export CPPFLAGS_CONDA_NVCC_BACKUP="\${CPPFLAGS:-}"
 fi
 
-if [[ ! -z "\${CXXFLAGS+x}" ]
+if [[ ! -z "\${CXXFLAGS+x}" ]]
 then
   export CXXFLAGS_CONDA_NVCC_BACKUP="\${CXXFLAGS:-}"
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set number = 4 %}
+{% set number = 5 %}
 
 package:
   name: "{{ name }}"


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes issue #22

<!--
Please add any other relevant info below:
-->

This PR introduces the following improvements for handling environment variables such as CUDA_HOME, CFLAGS, CXXFLAGS, and CPPFLAGS:
1. If a variable is not defined, don't create a backup variable (otherwise deactivation creates the variable with empty content)
2. On the second call of `conda install nvcc_linux` (say, when upgrading), nvcc deactivate script will reset CUDA_HOME to empty which breaks subsequent nvcc activation. This PR fixes this breakage.
3. If the stub `libcudart.so` exists, make a backup of the stub in nvcc activation, and restore it during deactivation.