### PR TITLE
Don't fail silently when CUDA environment is not set correctly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -31,7 +31,7 @@ fi
 # Default to using \$(cuda-gdb) to specify \$(CUDA_HOME).
 if [[ -z "\${CUDA_HOME+x}" ]]
 then
-    CUDA_GDB_EXECUTABLE=\$(which cuda-gdb)
+    CUDA_GDB_EXECUTABLE=\$(which cuda-gdb || exit 0)
     if [[ -n "\$CUDA_GDB_EXECUTABLE" ]]
     then
         CUDA_HOME=\$(dirname \$(dirname \$CUDA_GDB_EXECUTABLE))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set number = 5 %}
+{% set number = 6 %}
 
 package:
   name: "{{ name }}"


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

When CUDA environment is not set (e.g. `CUDA_HOME` is empty and `gdb-cuda` is not in `PATH`, ), then the activation script fails without any useful error message:
```
INFO: activate-binutils_linux-64.sh made the following environmental changes:
...
+GXX=$BUILD_PREFIX/bin/x86_64-conda_cos6-linux-gnu-g++
Traceback (most recent call last):
  File "/home/pearu/miniconda3/bin/conda-build", line 11, in <module>
    sys.exit(main())
  File "/home/pearu/miniconda3/lib/python3.7/site-packages/conda_build/cli/main_build.py", line 469, in main
    execute(sys.argv[1:])
  File "/home/pearu/miniconda3/lib/python3.7/site-packages/conda_build/cli/main_build.py", line 460, in execute
    verify=args.verify, variants=args.variants)
  File "/home/pearu/miniconda3/lib/python3.7/site-packages/conda_build/api.py", line 209, in build
    notest=notest, need_source_download=need_source_download, variants=variants)
  File "/home/pearu/miniconda3/lib/python3.7/site-packages/conda_build/build.py", line 2344, in build_tree
    notest=notest,
  File "/home/pearu/miniconda3/lib/python3.7/site-packages/conda_build/build.py", line 1492, in build
    cwd=src_dir, stats=build_stats)
  File "/home/pearu/miniconda3/lib/python3.7/site-packages/conda_build/utils.py", line 398, in check_call_env
    return _func_defaulting_env_to_os_environ('call', *popenargs, **kwargs)
  File "/home/pearu/miniconda3/lib/python3.7/site-packages/conda_build/utils.py", line 378, in _func_defaulting_env_to_os_environ
    raise subprocess.CalledProcessError(proc.returncode, _args)
subprocess.CalledProcessError: Command '['/bin/bash', '-o', 'errexit', '/home/pearu/miniconda3/conda-bld/omniscidb-cuda_1573886679616/work/conda_build.sh']' returned non-zero exit status 1.
```
The reason is that the activation script exits immidiately after unsuccesful `which gdb-cuda` call.

With this PR, the failure message will be:
```
INFO: activate-binutils_linux-64.sh made the following environmental changes:
...
+GXX=$BUILD_PREFIX/bin/x86_64-conda_cos6-linux-gnu-g++
Cannot determine CUDA_HOME: cuda-gdb not in PATH
Traceback (most recent call last):
...
```

Closes #30 