### PR TITLE
Add -ICONDA_PREFIX/include to nvcc

### DIFF
--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -127,6 +127,6 @@ EOF
 mkdir -p "${PREFIX}/bin"
 cat > "${PREFIX}/bin/nvcc" <<EOF
 #!/bin/bash
-"\${CUDA_HOME}/bin/nvcc" -ccbin "\${CXX}" \$@
+"\${CUDA_HOME}/bin/nvcc" -ccbin "\${CXX}" -I\${PREFIX}/include \$@
 EOF
 chmod +x "${PREFIX}/bin/nvcc"

--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -127,6 +127,6 @@ EOF
 mkdir -p "${PREFIX}/bin"
 cat > "${PREFIX}/bin/nvcc" <<EOF
 #!/bin/bash
-"\${CUDA_HOME}/bin/nvcc" -ccbin "\${CXX}" -I\${PREFIX}/include \$@
+"\${CUDA_HOME}/bin/nvcc" -ccbin "\${CXX}" -I\${CONDA_PREFIX}/include \$@
 EOF
 chmod +x "${PREFIX}/bin/nvcc"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set number = 5 %}
+{% set number = 6 %}
 
 package:
   name: "{{ name }}"


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR adds `-I$CONDA_PREFIX/include` to `nvcc` options to ease finding the library headers installed by conda.