### PR TITLE
Add CUDA 10.2 (manually)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -18,6 +18,10 @@ jobs:
         CONFIG: linux_cuda_compiler_version10.1target_platformlinux-64
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
+      linux_cuda_compiler_version10.2target_platformlinux-64:
+        CONFIG: linux_cuda_compiler_version10.2target_platformlinux-64
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
       linux_cuda_compiler_version9.2target_platformlinux-64:
         CONFIG: linux_cuda_compiler_version9.2target_platformlinux-64
         UPLOAD_PACKAGES: True

--- a/.ci_support/linux_cuda_compiler_version10.2target_platformlinux-64.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.2target_platformlinux-64.yaml
@@ -1,0 +1,23 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-cuda:10.2
+target_platform:
+- linux-64
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_cuda_compiler_version10.2target_platformlinux-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7480&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvcc-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_cuda_compiler_version9.2target_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7480&branchName=master">

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,17 @@
+cuda_compiler_version:         # [linux64]
+  - None                       # [linux64]
+  - 9.2                        # [linux64]
+  - 10.0                       # [linux64]
+  - 10.1                       # [linux64]
+  - 10.2                       # [linux64]
+
+docker_image:                                   # [linux]
+  - condaforge/linux-anvil-comp7                # [linux64]
+  - condaforge/linux-anvil-cuda:9.2             # [linux64]
+  - condaforge/linux-anvil-cuda:10.0            # [linux64]
+  - condaforge/linux-anvil-cuda:10.1            # [linux64]
+  - condaforge/linux-anvil-cuda:10.2            # [linux64]
+
+  - condaforge/linux-anvil-aarch64              # [aarch64]
+  - condaforge/linux-anvil-ppc64le              # [ppc64le]
+  - condaforge/linux-anvil-armv7l               # [armv7l]


### PR DESCRIPTION
Precedes PR ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/360 ), which will perform the CUDA 10.2 migration on feedstocks. This ensure that we get `nvcc` version `10.2` in place first (since it appears the migrator doesn't handle this part for us currently). Can be removed after the migration is complete and CUDA 10.2 is included by default.

cc @isuruf @CJ-Wright @scopatz @kkraus14 @mike-wendt @leofang

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
