### PR TITLE
[Windows] Freeze PKG_VERSION and add fallback lookup in default installation path

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set number = 7 %}
+{% set number = 8 %}
 
 package:
   name: "{{ name }}"
@@ -22,6 +22,8 @@ outputs:
           - cudatoolkit {{ cuda_compiler_version }}|{{ cuda_compiler_version }}.*
           - __glibc >=2.17  # [linux and cuda_compiler_version == "11.0"]
     requirements:
+      build:      # [win]
+        - m2-sed  # [win]
       host:
         # Needed to symlink libcuda into sysroot libs.
         - {{ compiler("c") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set number = 8 %}
+{% set number = 9 %}
 
 package:
   name: "{{ name }}"
@@ -65,3 +65,4 @@ extra:
     - kkraus14
     - mike-wendt
     - raydouglass
+    - jaimergp

--- a/recipe/windows/activate.bat
+++ b/recipe/windows/activate.bat
@@ -65,15 +65,15 @@ set "CXXFLAGS=%CXXFLAGS% -I%CUDA_HOME%\include"
 :: Stub is used to avoid getting driver code linked into binaries.
 
 :: Make a backup of `cuda.lib` if it exists -- we make sure this is the case in install_nvcc.bat
-if exist "__LIBRARY_LIB__\cuda.lib" (
-    set "LIBCUDA_SO_CONDA_NVCC_BACKUP=__LIBRARY_LIB__\cuda.lib-conda-nvcc-backup"
-    ren "__LIBRARY_LIB__\cuda.lib" "%LIBCUDA_SO_CONDA_NVCC_BACKUP%"
+if exist "%CONDA_PREFIX%\Library\lib\cuda.lib" (
+    set "LIBCUDA_SO_CONDA_NVCC_BACKUP=%CONDA_PREFIX%\Library\lib\cuda.lib-conda-nvcc-backup"
+    ren "%CONDA_PREFIX%\Library\lib\cuda.lib" "%LIBCUDA_SO_CONDA_NVCC_BACKUP%"
 )
 
-mkdir "__LIBRARY_LIB__"
+mkdir "%CONDA_PREFIX%\Library\lib"
 :: symlinking requires admin access or developer mode ON
 :: we fallback to a standard copy if mklink fails
-mklink "__LIBRARY_LIB__\cuda.lib" "%CUDA_HOME%\lib\x64\cuda.lib" || copy "%CUDA_HOME%\lib\x64\cuda.lib" "__LIBRARY_LIB__\cuda.lib"
+mklink "%CONDA_PREFIX%\Library\lib\cuda.lib" "%CUDA_HOME%\lib\x64\cuda.lib" || copy "%CUDA_HOME%\lib\x64\cuda.lib" "%CONDA_PREFIX%\Library\lib\cuda.lib"
 if errorlevel 1 (
     echo "Could not create link nor fallback copy"
     exit /b 1

--- a/recipe/windows/activate.bat
+++ b/recipe/windows/activate.bat
@@ -43,7 +43,7 @@ if not exist "%CUDA_PATH%\lib\x64\cuda.lib" (
     exit /b 1
 )
 
-findstr /c:"CUDA Version __PKG_VERSION__" "%CUDA_PATH%\version.txt"
+findstr /C:"CUDA Version __PKG_VERSION__" "%CUDA_PATH%\version.txt"
 if errorlevel 1 (
     :: CUDA 11 does not package a version.txt, so maybe it failed due to
     :: that. Let's double check with the output of nvcc.exe --version
@@ -65,12 +65,12 @@ set "CXXFLAGS=%CXXFLAGS% -I%CUDA_HOME%\include"
 :: Stub is used to avoid getting driver code linked into binaries.
 
 :: Make a backup of `cuda.lib` if it exists -- we make sure this is the case in install_nvcc.bat
-if exist __LIBRARY_LIB__\cuda.lib (
+if exist "__LIBRARY_LIB__\cuda.lib" (
     set "LIBCUDA_SO_CONDA_NVCC_BACKUP=__LIBRARY_LIB__\cuda.lib-conda-nvcc-backup"
     ren "__LIBRARY_LIB__\cuda.lib" "%LIBCUDA_SO_CONDA_NVCC_BACKUP%"
 )
 
-mkdir __LIBRARY_LIB__
+mkdir "__LIBRARY_LIB__"
 :: symlinking requires admin access or developer mode ON
 :: we fallback to a standard copy if mklink fails
 mklink "__LIBRARY_LIB__\cuda.lib" "%CUDA_HOME%\lib\x64\cuda.lib" || copy "%CUDA_HOME%\lib\x64\cuda.lib" "__LIBRARY_LIB__\cuda.lib"

--- a/recipe/windows/activate.bat
+++ b/recipe/windows/activate.bat
@@ -38,16 +38,16 @@ if not exist "%CUDA_PATH%\" (
     exit /b 1
 )
 
-@REM if not exist "%CUDA_PATH%\lib\x64\cuda.lib" (
-@REM     echo "File '%CUDA_PATH%\lib\x64\cuda.lib' doesn't exist"
-@REM     exit /b 1
-@REM )
+if not exist "%CUDA_PATH%\lib\x64\cuda.lib" (
+    echo "File '%CUDA_PATH%\lib\x64\cuda.lib' doesn't exist"
+    exit /b 1
+)
 
-findstr /c:"CUDA Version %PKG_VERSION%" "%CUDA_PATH%\version.txt"
+findstr /c:"CUDA Version __PKG_VERSION__" "%CUDA_PATH%\version.txt"
 if errorlevel 1 (
     :: CUDA 11 does not package a version.txt, so maybe it failed due to
     :: that. Let's double check with the output of nvcc.exe --version
-    "%CUDA_PATH%\bin\nvcc.exe" --version | findstr /C:"release %PKG_VERSION%"
+    "%CUDA_PATH%\bin\nvcc.exe" --version | findstr /C:"release __PKG_VERSION__"
     if errorlevel 1 (
         echo "Version of installed CUDA didn't match package or could not be determined."
         exit /b 1
@@ -65,15 +65,15 @@ set "CXXFLAGS=%CXXFLAGS% -I%CUDA_HOME%\include"
 :: Stub is used to avoid getting driver code linked into binaries.
 
 :: Make a backup of `cuda.lib` if it exists -- we make sure this is the case in install_nvcc.bat
-if exist %LIBRARY_LIB%\cuda.lib (
-    set "LIBCUDA_SO_CONDA_NVCC_BACKUP=%LIBRARY_LIB%\cuda.lib-conda-nvcc-backup"
-    ren "%LIBRARY_LIB%\cuda.lib" "%LIBCUDA_SO_CONDA_NVCC_BACKUP%"
+if exist __LIBRARY_LIB__\cuda.lib (
+    set "LIBCUDA_SO_CONDA_NVCC_BACKUP=__LIBRARY_LIB__\cuda.lib-conda-nvcc-backup"
+    ren "__LIBRARY_LIB__\cuda.lib" "%LIBCUDA_SO_CONDA_NVCC_BACKUP%"
 )
 
-mkdir %LIBRARY_LIB%
+mkdir __LIBRARY_LIB__
 :: symlinking requires admin access or developer mode ON
 :: we fallback to a standard copy if mklink fails
-mklink "%LIBRARY_LIB%\cuda.lib" "%CUDA_HOME%\lib\x64\cuda.lib" || copy "%CUDA_HOME%\lib\x64\cuda.lib" "%LIBRARY_LIB%\cuda.lib"
+mklink "__LIBRARY_LIB__\cuda.lib" "%CUDA_HOME%\lib\x64\cuda.lib" || copy "%CUDA_HOME%\lib\x64\cuda.lib" "__LIBRARY_LIB__\cuda.lib"
 if errorlevel 1 (
     echo "Could not create link nor fallback copy"
     exit /b 1

--- a/recipe/windows/deactivate.bat
+++ b/recipe/windows/deactivate.bat
@@ -37,7 +37,7 @@ if exist "%CUDALIB_CONDA_NVCC_BACKUP%" (
     :: We shouldn't need this because we did create an empty one just in case
     del "%CONDA_PREFIX%\Library\lib\cuda.lib"
     if errorlevel 1 (
-        echo Could not remove link/copy of `cuda.lib`!
+        echo Could not remove `cuda.lib` stub!
         exit /b 1
     )
 )

--- a/recipe/windows/deactivate.bat
+++ b/recipe/windows/deactivate.bat
@@ -30,12 +30,12 @@ if not "%CXXFLAGS_CONDA_NVCC_BACKUP%"=="" (
 )
 
 :: Remove or restore `cuda.lib` from the compiler sysroot.
-set "CUDALIB_CONDA_NVCC_BACKUP=%LIBRARY_LIB%\cuda.lib-conda-nvcc-backup"
+set "CUDALIB_CONDA_NVCC_BACKUP=__LIBRARY_LIB__\cuda.lib-conda-nvcc-backup"
 if exist "%CUDALIB_CONDA_NVCC_BACKUP%" (
-    ren "%CUDALIB_CONDA_NVCC_BACKUP%" "%LIBRARY_LIB%\cuda.lib"
+    ren "%CUDALIB_CONDA_NVCC_BACKUP%" "__LIBRARY_LIB__\cuda.lib"
 ) else (
     :: We shouldn't need this because we did create an empty one just in case
-    del "%LIBRARY_LIB%\cuda.lib"
+    del "__LIBRARY_LIB__\cuda.lib"
     if errorlevel 1 (
         echo Could not remove link/copy of `cuda.lib`!
         exit /b 1

--- a/recipe/windows/deactivate.bat
+++ b/recipe/windows/deactivate.bat
@@ -30,12 +30,12 @@ if not "%CXXFLAGS_CONDA_NVCC_BACKUP%"=="" (
 )
 
 :: Remove or restore `cuda.lib` from the compiler sysroot.
-set "CUDALIB_CONDA_NVCC_BACKUP=__LIBRARY_LIB__\cuda.lib-conda-nvcc-backup"
+set "CUDALIB_CONDA_NVCC_BACKUP=%CONDA_PREFIX%\Library\lib\cuda.lib-conda-nvcc-backup"
 if exist "%CUDALIB_CONDA_NVCC_BACKUP%" (
-    ren "%CUDALIB_CONDA_NVCC_BACKUP%" "__LIBRARY_LIB__\cuda.lib"
+    ren "%CUDALIB_CONDA_NVCC_BACKUP%" "%CONDA_PREFIX%\Library\lib\cuda.lib"
 ) else (
     :: We shouldn't need this because we did create an empty one just in case
-    del "__LIBRARY_LIB__\cuda.lib"
+    del "%CONDA_PREFIX%\Library\lib\cuda.lib"
     if errorlevel 1 (
         echo Could not remove link/copy of `cuda.lib`!
         exit /b 1

--- a/recipe/windows/install_nvcc.bat
+++ b/recipe/windows/install_nvcc.bat
@@ -4,13 +4,11 @@ setlocal enableextensions enabledelayedexpansion || goto :error
 :: Activation script
 mkdir %PREFIX%\etc\conda\activate.d
 :: Render conda-build env vars
-sed -i "s/__LIBRARY_LIB__/%LIBRARY_LIB%/g;s/__PKG_VERSION__/%PKG_VERSION%/g" %RECIPE_DIR%\windows\activate.bat
+sed -i "s/__PKG_VERSION__/%PKG_VERSION%/g" %RECIPE_DIR%\windows\activate.bat
 copy %RECIPE_DIR%\windows\activate.bat %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat || goto :error
 
 :: Deactivation script
 mkdir %PREFIX%\etc\conda\deactivate.d
-:: Render conda-build env vars
-sed -i "s/__LIBRARY_LIB__/%LIBRARY_LIB%/g" %RECIPE_DIR%\windows\deactivate.bat
 copy %RECIPE_DIR%\windows\deactivate.bat %PREFIX%\etc\conda\deactivate.d\%PKG_NAME%_deactivate.bat || goto :error
 
 :: nvcc executable wrapper

--- a/recipe/windows/install_nvcc.bat
+++ b/recipe/windows/install_nvcc.bat
@@ -3,10 +3,14 @@ setlocal enableextensions enabledelayedexpansion || goto :error
 
 :: Activation script
 mkdir %PREFIX%\etc\conda\activate.d
+:: Render conda-build env vars
+sed -i "s/__LIBRARY_LIB__/%LIBRARY_LIB%/g;s/__PKG_VERSION__/%PKG_VERSION%/g" %RECIPE_DIR%\windows\activate.bat
 copy %RECIPE_DIR%\windows\activate.bat %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat || goto :error
 
 :: Deactivation script
 mkdir %PREFIX%\etc\conda\deactivate.d
+:: Render conda-build env vars
+sed -i "s/__LIBRARY_LIB__/%LIBRARY_LIB%/g" %RECIPE_DIR%\windows\deactivate.bat
 copy %RECIPE_DIR%\windows\deactivate.bat %PREFIX%\etc\conda\deactivate.d\%PKG_NAME%_deactivate.bat || goto :error
 
 :: nvcc executable wrapper

--- a/recipe/windows/test_nvcc.bat
+++ b/recipe/windows/test_nvcc.bat
@@ -71,13 +71,13 @@ if "%CFLAGS%"=="%CFLAGS_CONDA_NVCC_TEST%" (
     echo "CFLAGS is incorrectly set to '%CFLAGS%', should be set to '%CFLAGS_CONDA_NVCC_TEST%'"
     exit 1
 )
-@REM :: If no previous cuda.lib was present, there shouldn't be any!
-@REM if "%CUDALIB_CONDA_NVCC_BACKUP%" == "" (
-@REM     if exist "%LIBRARY_LIB%\cuda.lib" (
-@REM         echo "%LIBRARY_LIB%\cuda.lib" should not exist!
-@REM         exit 1
-@REM     )
-@REM )
+:: If no previous cuda.lib was present, there shouldn't be any!
+if "%CUDALIB_CONDA_NVCC_BACKUP%" == "" (
+    if exist "%LIBRARY_LIB%\cuda.lib" (
+        echo "%LIBRARY_LIB%\cuda.lib" should not exist!
+        exit 1
+    )
+)
 
 :: Reactivate
 call %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

# Part 1

This fixes a subtle bug I just found for the activation scripts on Windows. Since we are not creating the activation scripts from the install script, but by copying them from files, environment variables are not rendered to the final file. Instead the take the value set in the environment when they are executed. For our tests that didn't matter because they got rendered correctly, but when used in other recipes, they might take the wrong value.

For example, the CUDA version check uses `PKG_VERSION`, which will be set for other packages during build time. [Example here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=245139&view=logs&j=84cf05f7-5267-5f38-137b-63208e75d05b&t=7c51bcc0-b6e0-5e4f-1968-7bb191e490bd&l=348). That `7.5.0` is OpenMM's version, not CUDA!

To fix this, I am rendering `PKG_VERSION` by hand, using `sed` 😬 

This is not producing errors because of the fallback mechanisms for finding `CUDA_HOME`, but that doesn't mean it should not be fixed. Especially if this package is used outside the context of conda-forge.

# Part 2

For some reason, in some feedstocks `conda-forge-ci-setup` mechanisms do not reach the recipe (e.g. `CUDA_PATH` is not set and `PATH` does not contain `nvcc.exe`). See #53 for more details.

As a workaround I am adding a fallback lookup in the default installation path, where the activation script might find nvcc.exe.

<!--
Please add any other relevant info below:
-->
