### PR TITLE
Remove version constraint of `nvcc` to match with host cuda version

### DIFF
--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -65,7 +65,13 @@ fi
 
 if [[ -z "\$(\${CUDA_HOME}/bin/nvcc --version | grep "Cuda compilation tools, release ${PKG_VERSION}")" ]]
 then
-  echo "Warning: Version of installed CUDA didn't match package"
+  if [[ ! -z "\${CONDA_BUILD_SYSROOT+x}" ]]
+  then
+    echo "Version of installed CUDA didn't match package"
+    return 1
+  else
+    echo "Warning: Version of installed CUDA didn't match package"
+  fi
 fi
 
 export CUDA_HOME="\${CUDA_HOME}"

--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -65,7 +65,7 @@ fi
 
 if [[ -z "\$(\${CUDA_HOME}/bin/nvcc --version | grep "Cuda compilation tools, release ${PKG_VERSION}")" ]]
 then
-  if [[ "\${CONDA_BUILD}"="1" ]]
+  if [[ "\${CONDA_BUILD}" = "1" ]]
   then
     echo "Version of installed CUDA didn't match package"
     return 1

--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -65,8 +65,7 @@ fi
 
 if [[ -z "\$(\${CUDA_HOME}/bin/nvcc --version | grep "Cuda compilation tools, release ${PKG_VERSION}")" ]]
 then
-  echo "Version of installed CUDA didn't match package"
-  return 1
+  echo "Warning: Version of installed CUDA didn't match package"
 fi
 
 export CUDA_HOME="\${CUDA_HOME}"

--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -65,7 +65,7 @@ fi
 
 if [[ -z "\$(\${CUDA_HOME}/bin/nvcc --version | grep "Cuda compilation tools, release ${PKG_VERSION}")" ]]
 then
-  if [[ ! -z "\${CONDA_BUILD+x}" ]]
+  if [[ "\${CONDA_BUILD}"="1" ]]
   then
     echo "Version of installed CUDA didn't match package"
     return 1

--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -65,7 +65,7 @@ fi
 
 if [[ -z "\$(\${CUDA_HOME}/bin/nvcc --version | grep "Cuda compilation tools, release ${PKG_VERSION}")" ]]
 then
-  if [[ ! -z "\${CONDA_BUILD_SYSROOT+x}" ]]
+  if [[ ! -z "\${CONDA_BUILD+x}" ]]
   then
     echo "Version of installed CUDA didn't match package"
     return 1

--- a/recipe/install_nvcc.sh
+++ b/recipe/install_nvcc.sh
@@ -67,7 +67,7 @@ if [[ -z "\$(\${CUDA_HOME}/bin/nvcc --version | grep "Cuda compilation tools, re
 then
   if [[ "\${CONDA_BUILD}" = "1" ]]
   then
-    echo "Version of installed CUDA didn't match package"
+    echo "Error: Version of installed CUDA didn't match package"
     return 1
   else
     echo "Warning: Version of installed CUDA didn't match package"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set number = 19 %}
+{% set number = 20 %}
 
 {% if cuda_compiler_version in (None, "None", True, False) %}
 {% set cuda_major = 0 %}


### PR DESCRIPTION
This PR removes the version constraint that `nvcc` imposes to have the matching CUDA version on the host machine installed. Upon some searching, relaxing & testing this fix it appears that there is no version-specific file being shipped along with `nvcc` conda package, but I could be wrong here too. Hence requesting review from maintainers since this check has been present since its inception.

Rationale behind this PR is to allow users to utilized any version of `nvcc` package without upgrading their local host CUDA installations.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
