### PR TITLE
Fix nvcc on Windows

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -83,10 +83,12 @@ jobs:
         call activate base
         run_conda_forge_build_setup
       displayName: conda-forge build setup
-    
 
     - script: |
         call activate base
+        if EXIST LICENSE.txt (
+          copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
+        )
         conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
       displayName: Build recipe
       env:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -24,7 +24,10 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 
@@ -45,6 +48,10 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
+  cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
+BSD-3-Clause license
 Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/README.md
+++ b/README.md
@@ -320,6 +320,9 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-nvcc_linux--64-green.svg)](https://anaconda.org/conda-forge/nvcc_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nvcc_linux-64.svg)](https://anaconda.org/conda-forge/nvcc_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nvcc_linux-64.svg)](https://anaconda.org/conda-forge/nvcc_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nvcc_linux-64.svg)](https://anaconda.org/conda-forge/nvcc_linux-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-nvcc_linux--aarch64-green.svg)](https://anaconda.org/conda-forge/nvcc_linux-aarch64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nvcc_linux-aarch64.svg)](https://anaconda.org/conda-forge/nvcc_linux-aarch64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nvcc_linux-aarch64.svg)](https://anaconda.org/conda-forge/nvcc_linux-aarch64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nvcc_linux-aarch64.svg)](https://anaconda.org/conda-forge/nvcc_linux-aarch64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-nvcc_linux--ppc64le-green.svg)](https://anaconda.org/conda-forge/nvcc_linux-ppc64le) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nvcc_linux-ppc64le.svg)](https://anaconda.org/conda-forge/nvcc_linux-ppc64le) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nvcc_linux-ppc64le.svg)](https://anaconda.org/conda-forge/nvcc_linux-ppc64le) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nvcc_linux-ppc64le.svg)](https://anaconda.org/conda-forge/nvcc_linux-ppc64le) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-nvcc_win--64-green.svg)](https://anaconda.org/conda-forge/nvcc_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nvcc_win-64.svg)](https://anaconda.org/conda-forge/nvcc_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nvcc_win-64.svg)](https://anaconda.org/conda-forge/nvcc_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nvcc_win-64.svg)](https://anaconda.org/conda-forge/nvcc_win-64) |
 
 Installing nvcc
 ===============
@@ -331,16 +334,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `nvcc_linux-64` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `nvcc_linux-64, nvcc_linux-aarch64, nvcc_linux-ppc64le, nvcc_win-64` can be installed with `conda`:
 
 ```
-conda install nvcc_linux-64
+conda install nvcc_linux-64 nvcc_linux-aarch64 nvcc_linux-ppc64le nvcc_win-64
 ```
 
 or with `mamba`:
 
 ```
-mamba install nvcc_linux-64
+mamba install nvcc_linux-64 nvcc_linux-aarch64 nvcc_linux-ppc64le nvcc_win-64
 ```
 
 It is possible to list all of the versions of `nvcc_linux-64` available on your platform with `conda`:

--- a/build-locally.py
+++ b/build-locally.py
@@ -86,12 +86,19 @@ def main(args=None):
     verify_config(ns)
     setup_environment(ns)
 
-    if ns.config.startswith("linux") or (
-        ns.config.startswith("osx") and platform.system() == "Linux"
-    ):
-        run_docker_build(ns)
-    elif ns.config.startswith("osx"):
-        run_osx_build(ns)
+    try:
+        if ns.config.startswith("linux") or (
+            ns.config.startswith("osx") and platform.system() == "Linux"
+        ):
+            run_docker_build(ns)
+        elif ns.config.startswith("osx"):
+            run_osx_build(ns)
+    finally:
+        recipe_license_file = os.path.join(
+            "recipe", "recipe-scripts-license.txt"
+        )
+        if os.path.exists(recipe_license_file):
+            os.remove(recipe_license_file)
 
 
 if __name__ == "__main__":

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nvcc" %}
-{% set number = 19 %}
+{% set number = 20 %}
 
 {% if cuda_compiler_version in (None, "None", True, False) %}
 {% set cuda_major = 0 %}

--- a/recipe/windows/nvcc_windows.bat
+++ b/recipe/windows/nvcc_windows.bat
@@ -1,1 +1,1 @@
-"%CUDA_HOME%\bin\nvcc.exe" --use-local-env %*
+"%CUDA_HOME%\bin\nvcc.exe" --use-local-env -ccbin "%CXX%" %*

--- a/recipe/windows/nvcc_windows.bat
+++ b/recipe/windows/nvcc_windows.bat
@@ -1,1 +1,1 @@
-"%CUDA_HOME%\bin\nvcc.exe" -ccbin "%CXX% --use-local-env" %*
+"%CUDA_HOME%\bin\nvcc.exe" -ccbin "%CXX%" --use-local-env %*

--- a/recipe/windows/nvcc_windows.bat
+++ b/recipe/windows/nvcc_windows.bat
@@ -1,1 +1,1 @@
-"%CUDA_HOME%\bin\nvcc.exe" -ccbin "%CXX%" --use-local-env %*
+"%CUDA_HOME%\bin\nvcc.exe" --use-local-env %*

--- a/recipe/windows/nvcc_windows.bat
+++ b/recipe/windows/nvcc_windows.bat
@@ -1,2 +1,2 @@
-for /f "tokens=* usebackq" %%f in (`where cl.exe`) do (set "CONDA_NVCC_CCBIN=%%~dpf")
+for /f "tokens=* usebackq" %%f in (`where cl.exe`) do (set "CONDA_NVCC_CCBIN=%%~dpf:\=\\%%")
 "%CUDA_HOME%\bin\nvcc.exe" --use-local-env -ccbin "%CONDA_NVCC_CCBIN%" %*

--- a/recipe/windows/nvcc_windows.bat
+++ b/recipe/windows/nvcc_windows.bat
@@ -1,2 +1,2 @@
-for /f "tokens=* usebackq" %%f in (`where cl.exe`) do (set "CONDA_NVCC_CCBIN=%%~dpf:\=\\%%")
+for /f "tokens=* usebackq" %%f in (`where cl.exe`) do (set "dummy=%%~dpf" && call set "CONDA_NVCC_CCBIN=%%dummy:\=\\%%")
 "%CUDA_HOME%\bin\nvcc.exe" --use-local-env -ccbin "%CONDA_NVCC_CCBIN%" %*

--- a/recipe/windows/nvcc_windows.bat
+++ b/recipe/windows/nvcc_windows.bat
@@ -1,1 +1,1 @@
-"%CUDA_HOME%\bin\nvcc.exe" -ccbin "%CXX%" --use-local-env %*
+"%CUDA_HOME%\bin\nvcc.exe" -ccbin "%CXX% --use-local-env" %*

--- a/recipe/windows/nvcc_windows.bat
+++ b/recipe/windows/nvcc_windows.bat
@@ -1,2 +1,2 @@
-for /f "tokens=* usebackq" %%f in (`where cl.exe`) do (set "dummy=%%~dpf" && call set "CONDA_NVCC_CCBIN=%%dummy:\=\\%%")
+for /f "tokens=* usebackq" %%f in (`where cl.exe`) do (set "dummy=%%f" && call set "CONDA_NVCC_CCBIN=%%dummy:\=\\%%")
 "%CUDA_HOME%\bin\nvcc.exe" --use-local-env -ccbin "%CONDA_NVCC_CCBIN%" %*

--- a/recipe/windows/nvcc_windows.bat
+++ b/recipe/windows/nvcc_windows.bat
@@ -1,1 +1,1 @@
-"%CUDA_HOME%\bin\nvcc.exe" -ccbin "%CXX%" %*
+"%CUDA_HOME%\bin\nvcc.exe" -ccbin "%CXX%" --use-local-env %*

--- a/recipe/windows/nvcc_windows.bat
+++ b/recipe/windows/nvcc_windows.bat
@@ -1,2 +1,3 @@
-for /f "tokens=* usebackq" %%f in (`where cl.exe`) do (set "dummy=%%f" && call set "CONDA_NVCC_CCBIN=%%dummy:\=\\%%")
+echo %PATH%
+for /f "tokens=* usebackq" %%f in (`where cl.exe`) do set "CONDA_NVCC_CCBIN=%%f"
 "%CUDA_HOME%\bin\nvcc.exe" --use-local-env -ccbin "%CONDA_NVCC_CCBIN%" %*

--- a/recipe/windows/nvcc_windows.bat
+++ b/recipe/windows/nvcc_windows.bat
@@ -1,1 +1,2 @@
-"%CUDA_HOME%\bin\nvcc.exe" --use-local-env -ccbin "%CXX%" %*
+for /f "tokens=* usebackq" %%f in (`where cl.exe`) do (set "CONDA_NVCC_CCBIN=%%~dpf")
+"%CUDA_HOME%\bin\nvcc.exe" --use-local-env -ccbin "%CONDA_NVCC_CCBIN%" %*

--- a/recipe/windows/test_nvcc.bat
+++ b/recipe/windows/test_nvcc.bat
@@ -70,4 +70,4 @@ call %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat
 if errorlevel 1 exit 1
 
 :: Try building something
-nvcc test.cu -o test
+nvcc test.cu

--- a/recipe/windows/test_nvcc.bat
+++ b/recipe/windows/test_nvcc.bat
@@ -70,4 +70,4 @@ call %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat
 if errorlevel 1 exit 1
 
 :: Try building something
-nvcc test.cu
+nvcc.bat test.cu

--- a/recipe/windows/test_nvcc.bat
+++ b/recipe/windows/test_nvcc.bat
@@ -70,4 +70,4 @@ call %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat
 if errorlevel 1 exit 1
 
 :: Try building something
-nvcc.bat test.cu
+nvcc test.cu -o test


### PR DESCRIPTION
Close #76.

The common symptom, likely triggered after the vs2019 update, is this error
```
'cl.exe' is not recognized as an internal or external command,
operable program or batch file.
```
We need to use the [`--use-local-env`](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-guiding-compiler-driver-use-local-env) flag to respect conda-forge's MSVC setup.
> Skip MSVC environment initialization.
> By default nvcc assumes that the MSVC environment needs to be initialized. This is done by executing the appropriate command file available for the MSVC installation detected or specified. Initializing the environment for each nvcc invocation can add noticeable overheads. If the environment used to invoke nvcc has already been configured, this option can be used to skip this step.

cc: @isuruf @carterbox

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
