### PR TITLE
Use `pin_compatible` for `cudatoolkit` & `sysroot`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,9 @@ build:
 
 outputs:
   - name: nvcc_{{ cross_target_platform }}
-    script: linux/install_nvcc.sh     # [linux]
-    script: windows/install_nvcc.bat  # [win]
+    {% set script = "linux/install_nvcc.sh" %}     # [linux]
+    {% set script = "windows/install_nvcc.bat" %}  # [win]
+    script: {{ script }}
     build:
       ignore_run_exports_from:
         - {{ c_compiler }}_{{ cross_target_platform }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ cuda_compiler_version }}
 
 build:
-  number: 25
+  number: 26
   skip: {{ not (compiler("cuda").startswith("nvcc") and cuda_compiler_version == "11.8") }}
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,3 @@
-{% if cuda_compiler_version in (None, "None", True, False) %}
-{% set cuda_major = 0 %}
-{% else %}
-{% set cuda_major = environ.get("cuda_compiler_version", "11.8").split(".")[0]|int %}
-{% endif %}
-
 {% if cross_target_platform is undefined %}
 {% set cross_target_platform = target_platform %}
 {% endif %}
@@ -17,7 +11,7 @@ build:
   skip: {{ not (compiler("cuda").startswith("nvcc") and cuda_compiler_version == "11.8") }}
 
 outputs:
-  - name: nvcc_{{ cross_target_platform }}
+  - name: {{ cuda_compiler }}_{{ cross_target_platform }}
     {% set script = "linux/install_nvcc.sh" %}     # [linux]
     {% set script = "windows/install_nvcc.bat" %}  # [win]
     script: {{ script }}
@@ -26,21 +20,22 @@ outputs:
         - {{ c_compiler }}_{{ cross_target_platform }}
       run_exports:
         strong:
-          - cudatoolkit >={{ cuda_compiler_version }},<{{ cuda_major + 1 }}
-          - sysroot_{{ cross_target_platform }} >={{ c_stdlib_version }}    # [linux]
+          - {{ pin_compatible("cudatoolkit") }}
+          - {{ pin_compatible(c_stdlib ~ "_" ~ cross_target_platform) }}  # [linux]
     requirements:
       build:      # [win]
         - m2-sed  # [win]
       host:
-        - {{ stdlib("c") }}
         # Needed to symlink libcuda into sysroot libs.
         - {{ c_compiler }}_{{ cross_target_platform }} {{ c_compiler_version }}.*       # [linux]
         - {{ c_compiler }}_{{ cross_target_platform }}                                  # [win]
-        - sysroot_{{ cross_target_platform }} >={{ c_stdlib_version }}  # [linux]
+        - {{ c_stdlib }}_{{ cross_target_platform }} {{ c_stdlib_version }}             # [linux]
+        - {{ c_stdlib }}_{{ cross_target_platform }}                                    # [win]
+        - cudatoolkit {{ cuda_compiler_version }}
       run:
-        - cudatoolkit >={{ cuda_compiler_version }},<{{ cuda_major + 1 }}
-        - sed                                                           # [linux]
-        - sysroot_{{ cross_target_platform }} >={{ c_stdlib_version }}  # [linux]
+        - {{ pin_compatible("cudatoolkit") }}
+        - sed                                                                           # [linux]
+        - {{ pin_compatible(c_stdlib ~ "_" ~ cross_target_platform) }}                  # [linux]
     test:
       requires:
         - {{ c_compiler }}_{{ cross_target_platform }} {{ c_compiler_version }}.*       # [linux]


### PR DESCRIPTION
Fix a package constraint bug where `sysroot` lacked an upper bound. Thus it is constrained within `>=2.17,<3.0a0`

Do this by adding pinned dependencies in `requirements/host` and then using `pin_compatible` to constrain these in `run_exports` and `run` (instead of rolling our own solution as before). This lines up with the logic `cuda-nvcc` currently uses

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
